### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -32,9 +32,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private org repositories using the inherited GITHUB_TOKEN.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 50
     with:
       module-repo: ${{ github.repository }}
@@ -45,9 +45,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private org repositories using the inherited GITHUB_TOKEN.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 50
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # No checkout or GitHub API usage; only derives the branch name for downstream jobs.
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private org repositories using the inherited GITHUB_TOKEN.
+    timeout-minutes: 50
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private org repositories using the inherited GITHUB_TOKEN.
+    timeout-minutes: 50
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -35,7 +35,6 @@ jobs:
     permissions:
       contents: read # Required for the reusable workflow to clone private org repositories using the inherited GITHUB_TOKEN.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
-    timeout-minutes: 50
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -48,7 +47,6 @@ jobs:
     permissions:
       contents: read # Required for the reusable workflow to clone private org repositories using the inherited GITHUB_TOKEN.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
-    timeout-minutes: 50
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # No checkout or GitHub API usage; only derives the branch name for downstream jobs.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone private org repositories using the inherited GITHUB_TOKEN.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone private org repositories using the inherited GITHUB_TOKEN.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -42,4 +42,3 @@ jobs:
       minimum-coverage: 25
     secrets:
       repo_token: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 50

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # No repository or GitHub API access; only writes workflow outputs from github context.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow (secrets.repo_token = GITHUB_TOKEN) to clone the repo and push coverage to gh-pages.
+      pull-requests: write # Required for the reusable workflow to add or update PR comments with coverage results.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # No repository or GitHub API access; only writes workflow outputs from github context.
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -41,3 +42,4 @@ jobs:
       minimum-coverage: 25
     secrets:
       repo_token: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 50

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -31,10 +31,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write      # Required for the reusable workflow (secrets.repo_token = GITHUB_TOKEN) to clone the repo and push coverage to gh-pages.
       pull-requests: write # Required for the reusable workflow to add or update PR comments with coverage results.
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
       contents: read       # Required for actions/checkout and technote-space/get-diff-action to read the repository tree.
       pull-requests: read  # Required for technote-space/get-diff-action to read the pull request diff via the GitHub API on pull_request events.
       actions: write        # Required for actions/cache to restore and save the Composer dependency cache.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,6 @@ jobs:
     permissions:
       contents: read       # Required for actions/checkout and technote-space/get-diff-action to read the repository tree.
       pull-requests: read  # Required for technote-space/get-diff-action to read the pull request diff via the GitHub API on pull_request events.
-      actions: write        # Required for actions/cache to restore and save the Composer dependency cache.
     timeout-minutes: 30
     steps:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required for actions/checkout and technote-space/get-diff-action to read the repository tree.
+      pull-requests: read  # Required for technote-space/get-diff-action to read the pull request diff via the GitHub API on pull_request events.
+      actions: write        # Required for actions/cache to restore and save the Composer dependency cache.
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for actions/checkout to clone this private repository with GITHUB_TOKEN.
+    timeout-minutes: 10
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -8,10 +8,16 @@ on:
 env:
   VERSION: ${GITHUB_REF#refs/tags/*}
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required for actions/checkout to clone this private repository with GITHUB_TOKEN.
     steps:
 
       - name: Checkout


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/wp-module-atomic/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 4 (`brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `lint.yml`, `satis-webhook.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `ffda55b` |
| Timeouts commit | `0ceeba6` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |
| Workflows that had a non-empty top-level `permissions` (replaced with default-deny `permissions: {}` and the standard comment block immediately above `jobs:` in this run): | `brand-plugin-test-playwright.yml` |
| Workflows that had a non-empty top-level `permissions` (replaced with default-deny `permissions: {}` and the standard comment block immediately above `jobs:` in this run): | `codecoverage-main.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | — | `Run PHP Code Sniffer` (`phpcs`) -> `contents: read`, `pull-requests: read`, `actions: write` [3] |
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | — | `Send Webhook` (`webhook`) -> `contents: read` [3] |
| brand-plugin-test-playwright.yml | 0 jobs were missing a scoped `permissions:` directive (all jobs already declared `permissions:`; `setup` was tightened — see corrections) | — | — |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: workflow top-level: BEFORE `permissions: contents: read` -> AFTER `permissions: {}` (with the required preceding comment block) -- align with default-deny workflow permissions and move all grants to jobs -- [3] |
| 2 | `brand-plugin-test-playwright.yml` :: workflow top-level: BEFORE `permissions: contents: read` -> AFTER `permissions: {}` (with the required preceding comment block) -- same rationale as above -- [3] |
| 3 | `brand-plugin-test-playwright.yml` :: `Setup` (`setup`): BEFORE `contents: read` -> AFTER `permissions: {}` -- job does not check out code and does not use `GITHUB_TOKEN` against the GitHub API -- [3] |
| 4 | `codecoverage-main.yml` :: `codecoverage`: adjusted job wiring so `uses:` precedes `permissions:`; expanded `contents: write` / `pull-requests: write` with least-privilege inline rationale for the reusable workflow + `GITHUB_TOKEN` usage -- [3] |
| 5 | `brand-plugin-test-playwright.yml` :: `Bluehost Build and Test Playwright` (`bluehost`), `Bluehost Dev Build and Test Playwright` (`bluehost-dev`): adjusted job wiring so `uses:` precedes `permissions:`; added inline rationale for `contents: read` needed for `secrets: inherit` / reusable workflow checkouts of private org repos -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| codecoverage-main.yml | get-repo-name | `5` | metadata-only job; should finish almost immediately, but a hard cap prevents a stuck runner. |
| codecoverage-main.yml | codecoverage | `50` | delegates to a long-running reusable matrix (multi-PHP tests + coverage); set slightly above the callee job timeout to reduce spurious cancellations. |
| — | — | — | `brand-plugin-test-playwright.yml` :: `Setup` (`setup`) -> `5` -- branch extraction only; should be seconds. |
| — | — | — | `brand-plugin-test-playwright.yml` :: `Bluehost Build and Test Playwright` (`bluehost`) -> `50` -- builds a brand plugin, installs deps, runs Playwright; matches the reusable workflow’s heavy runtime. |
| — | — | — | `brand-plugin-test-playwright.yml` :: `Bluehost Dev Build and Test Playwright` (`bluehost-dev`) -> `50` -- same rationale as `bluehost`, plus an extra artifact name variant. |
| — | — | — | `satis-webhook.yml` :: `Send Webhook` (`webhook`) -> `10` -- checkout + repository dispatch should complete quickly; cap prevents indefinite runs if networking hangs. |
| — | — | — | `lint.yml` :: `Run PHP Code Sniffer` (`phpcs`) -> `30` -- Composer install + PHPCS over diffs is usually fast, but allows headroom on cold caches. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Verified `.github/workflows/*.yml` presence via repository glob (4 files). A Glob call with the literal path including `.../wp-module-atomic/.github/workflows/*.yml` returned no matches in this environment, but the directory is non-empty and was scanned. |
| 2 | `peter-evans/repository-dispatch` authenticates with `secrets.WEBHOOK_TOKEN`; job `GITHUB_TOKEN` permissions need only cover `actions/checkout` of this repo (`contents: read`) [3]. |
| 3 | Reusable workflows in `newfold-labs/workflows` define their own job permissions; effective scopes for `GITHUB_TOKEN` in those runs follow GitHub’s caller/callee permission intersection rules—if a future callee step requires an additional scope (for example artifacts) beyond what either side grants, that would need coordinated updates in the shared workflow and/or caller [2]. |


